### PR TITLE
Figure out some edge cases

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,6 @@ in
       };
     };
   example =
-    assert example.config.string-consumer.output.string == "aaa";
+    assert example.config.string-consumer.output.string == "a a a";
     example;
 }

--- a/example/default.nix
+++ b/example/default.nix
@@ -8,9 +8,9 @@
   config = {
     # the integrator can set input parameters
     string-consumer.input.character = "a";
-    # configure a provider's specific options
-    string-provider."space separated".settings.inBetween = " ";
+    # configure a specific provider
+    string-providers."space separated".settings.inBetween = " ";
     # and choose a provider
-    string-consumer.provider = config.string-provider.provider;
+    string-consumer.provider = config.string-providers."space separated".provider;
   };
 }

--- a/example/default.nix
+++ b/example/default.nix
@@ -8,7 +8,9 @@
   config = {
     # the integrator can set input parameters
     string-consumer.input.character = "a";
+    # configure a provider's specific options
+    string-provider."space separated".settings.inBetween = " ";
     # and choose a provider
-    string-consumer.provider = config.string-provider;
+    string-consumer.provider = config.string-provider.provider;
   };
 }

--- a/example/string-consumer.nix
+++ b/example/string-consumer.nix
@@ -7,7 +7,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption;
 in
 {
   options = {

--- a/example/string-provider.nix
+++ b/example/string-provider.nix
@@ -12,11 +12,11 @@ in
 {
   options.string-provider = mkOption {
     type = config.interfaces.repeat-character.provider;
-    default = input: provider: {
-      inherit input; # sorry, boilerplate (for type safety)
-      output.string =
-        with lib;
-        concatStringsSep "" (genList (_: provider.config.input.character) provider.config.input.length);
-    };
+  };
+
+  config.string-provider = input: provider: {
+    output.string =
+      with lib;
+      concatStringsSep "" (genList (_: input.character) input.length);
   };
 }

--- a/example/string-provider.nix
+++ b/example/string-provider.nix
@@ -10,11 +10,16 @@ let
   inherit (lib) mkOption types;
 in
 {
-  options.string-provider = mkOption {
-    type = with types; submodule {
+  options.string-providers = mkOption {
+    type = with types; attrsOf (submodule (providerSpecific: {
       options = {
         provider = mkOption {
           type = config.interfaces.repeat-character.provider;
+          default = input: provider: {
+            output.string =
+              with lib;
+              concatStringsSep providerSpecific.config.settings.inBetween (genList (_: input.character) input.length);
+          };
         };
         settings = mkOption {
           type = submodule {
@@ -27,12 +32,6 @@ in
           };
         };
       };
-    };
-  };
-
-  config.string-provider.provider = input: provider: {
-    output.string =
-      with lib;
-      concatStringsSep config.string-provider.settings.inBetween (genList (_: input.character) input.length);
+    }));
   };
 }

--- a/example/string-provider.nix
+++ b/example/string-provider.nix
@@ -11,12 +11,28 @@ let
 in
 {
   options.string-provider = mkOption {
-    type = config.interfaces.repeat-character.provider;
+    type = with types; submodule {
+      options = {
+        provider = mkOption {
+          type = config.interfaces.repeat-character.provider;
+        };
+        settings = mkOption {
+          type = submodule {
+            options = {
+              inBetween = mkOption {
+                type = enum [ "" " " "-" "/" ];
+                default = "";
+              };
+            };
+          };
+        };
+      };
+    };
   };
 
-  config.string-provider = input: provider: {
+  config.string-provider.provider = input: provider: {
     output.string =
       with lib;
-      concatStringsSep "" (genList (_: input.character) input.length);
+      concatStringsSep config.string-provider.settings.inBetween (genList (_: input.character) input.length);
   };
 }


### PR DESCRIPTION
Tries some edge cases and see if we need to tweak the interface definition to accommodate them:

- Use directly `input`, reducing boilerplate.
- Add provider specific option.
- Uses provider option type inside an `attrsOf`.

---

Previous description:

> Compared to the string example, it:
> 
> - Uses attrsOf to create multiple provider instances.
> - Adds provider specific options with values different for each instance.
> 
> This is WIP because I'd like to create a NixOS test for this so I can actually use `pkgs.writeText`. Actually, it could work without using NixOS tests as long as we import the correct modules. Also, I'd like to add a provider for sops, not sure yet how to do that.
> 
> 